### PR TITLE
TabDJ: MV2 → MV3 Migration Summary

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,90 +1,98 @@
-var tabs = {};
+const tabStates = {};
+let creatingOffscreen = null;
 
-browser.extension.onConnect.addListener(function(port)
-{
-	port.onMessage.addListener(function(msg)
-	{
-		var curTab = msg.tabid;
-		
-		if (!curTab)
-		{
-			return;
-		}
-		
-		if (curTab < 0)
-		{
-			return;
-		}
-		
-		if (!tabs[curTab])
-		{
-			tabs[curTab] = {};
-			tabs[curTab].panning = 0;
-            tabs[curTab].volume = 1;
-			tabs[curTab].enabled = 0;
-			tabs[curTab].panNode;
-			tabs[curTab].context;
-			tabs[curTab].source;
-		}
-		
-		if (msg.type == 'set_request')
-		{
-			tabs[curTab].panning = msg.value[0];
-            tabs[curTab].volume = msg.value[1];            
-			
-			if (tabs[curTab].enabled == 0)
-			{
-				browser.tabCapture.capture(
-				{
-					audio: true,
-					video: false
-				}, function (stream)
-				{
-					tabs[curTab].context = new AudioContext();
-					tabs[curTab].source = tabs[curTab].context.createMediaStreamSource(stream);
-					
-                    tabs[curTab].gainNode = tabs[curTab].context.createGain();
-                    tabs[curTab].gainNode.gain.setValueAtTime(tabs[curTab].volume, tabs[curTab].context.currentTime);
-                    
-					tabs[curTab].panNode = tabs[curTab].context.createStereoPanner();
-					tabs[curTab].panNode.pan.setValueAtTime(tabs[curTab].panning, tabs[curTab].context.currentTime);
-					
-					tabs[curTab].source.connect(tabs[curTab].gainNode).connect(tabs[curTab].panNode).connect(tabs[curTab].context.destination);
-				});
-				
-				tabs[curTab].enabled = 1;
-			}
-			else
-			{
-                if (typeof tabs[curTab].panNode !== "undefined" && typeof tabs[curTab].panNode.pan !== "undefined" && typeof tabs[curTab].gainNode !== "undefined" && typeof tabs[curTab].gainNode.gain !== "undefined") {
-    				tabs[curTab].panNode.pan.setValueAtTime(tabs[curTab].panning, tabs[curTab].context.currentTime);
-                    tabs[curTab].gainNode.gain.setValueAtTime(tabs[curTab].volume, tabs[curTab].context.currentTime);
-                }
-			}
-		}
-		else if (msg.type == 'update_request')
-		{
-			var msgdata = {
-				'type':'update_response',
-				'value': [
-                    tabs[curTab].panning,
-                    tabs[curTab].volume
-                ],
-				'tabid': curTab
-			};
-			
-			port.postMessage(msgdata);
-		}
-		else if (mst.type == 'resetall_request')
-		{
-			
-		}
-	});
+// Restore panning/volume state that survived a service-worker restart.
+// The offscreen document keeps the audio graph alive independently, so
+// we only need to remember the user's last-set values.
+chrome.storage.session.get('tabStates').then(({ tabStates: stored }) => {
+    if (stored) Object.assign(tabStates, stored);
 });
 
-browser.tabs.onRemoved.addListener(function(tabid, removed) {
-	if (tabs[tabid])
-	{
-		delete tabs[tabid];
-	}
+function saveTabStates() {
+    chrome.storage.session.set({ tabStates });
+}
+
+async function ensureOffscreenDocument() {
+    const url = chrome.runtime.getURL('offscreen.html');
+    const existing = await chrome.runtime.getContexts({
+        contextTypes: ['OFFSCREEN_DOCUMENT'],
+        documentUrls: [url]
+    });
+    if (existing.length > 0) return;
+
+    // Guard against concurrent calls racing into createDocument.
+    if (!creatingOffscreen) {
+        creatingOffscreen = chrome.offscreen.createDocument({
+            url: 'offscreen.html',
+            reasons: [chrome.offscreen.Reason.AUDIO_PLAYBACK],
+            justification: 'Process captured tab audio for stereo panning and volume control'
+        }).finally(() => { creatingOffscreen = null; });
+    }
+    await creatingOffscreen;
+}
+
+chrome.runtime.onConnect.addListener((port) => {
+    port.onMessage.addListener(async (msg) => {
+        const tabId = msg.tabid;
+        if (!tabId || tabId < 0) return;
+
+        if (!tabStates[tabId]) {
+            tabStates[tabId] = { panning: 0, volume: 1, enabled: false };
+        }
+        const state = tabStates[tabId];
+
+        if (msg.type === 'set_request') {
+            state.panning = parseFloat(msg.value[0]);
+            state.volume = parseFloat(msg.value[1]);
+            saveTabStates();
+
+            await ensureOffscreenDocument();
+
+            if (!state.enabled) {
+                // Mark enabled before the async gap so a second rapid set_request
+                // takes the update_audio path rather than starting a second capture.
+                state.enabled = true;
+                saveTabStates();
+
+                const streamId = await new Promise((resolve) =>
+                    chrome.tabCapture.getMediaStreamId({ targetTabId: tabId }, resolve)
+                );
+
+                chrome.runtime.sendMessage({
+                    target: 'offscreen',
+                    type: 'capture_tab',
+                    tabId,
+                    streamId,
+                    panning: state.panning,
+                    volume: state.volume
+                }).catch(() => {});
+            } else {
+                chrome.runtime.sendMessage({
+                    target: 'offscreen',
+                    type: 'update_audio',
+                    tabId,
+                    panning: state.panning,
+                    volume: state.volume
+                }).catch(() => {});
+            }
+        } else if (msg.type === 'update_request') {
+            port.postMessage({
+                type: 'update_response',
+                value: [state.panning, state.volume],
+                tabid: tabId
+            });
+        }
+    });
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+    if (tabStates[tabId]) {
+        delete tabStates[tabId];
+        saveTabStates();
+        chrome.runtime.sendMessage({
+            target: 'offscreen',
+            type: 'release_tab',
+            tabId
+        }).catch(() => {});
+    }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -1,25 +1,21 @@
 {
     "name": "__MSG_appName__",
-    "version": "0.4",
+    "version": "0.5",
     "short_name": "Tab DJ",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-	"permissions": ["tabCapture", "activeTab"],
+    "permissions": ["tabCapture", "activeTab", "offscreen", "storage"],
     "background": {
-        "scripts": [
-            "browser-polyfill/browser-polyfill.min.js",
-            "background.js"
-        ],
-        "persistent": true
+        "service_worker": "background.js"
     },
-    "browser_action": {
-		"default_title": "Tab DJ",
+    "action": {
+        "default_title": "Tab DJ",
         "default_icon": "icon-48.png",
-		"default_popup": "popup.html"
+        "default_popup": "popup.html"
     },
     "icons": {
         "128": "icon-128.png",
         "48": "icon-48.png"
     },
-    "manifest_version": 2
+    "manifest_version": 3
 }

--- a/offscreen.html
+++ b/offscreen.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body><script src="offscreen.js"></script></body>
+</html>

--- a/offscreen.js
+++ b/offscreen.js
@@ -1,0 +1,72 @@
+// Keyed by tabId. Holds the live Web Audio graph for each captured tab.
+const tabAudio = {};
+
+chrome.runtime.onMessage.addListener((msg) => {
+    if (msg.target !== 'offscreen') return;
+
+    switch (msg.type) {
+        case 'capture_tab':
+            captureTab(msg.tabId, msg.streamId, msg.panning, msg.volume);
+            break;
+        case 'update_audio':
+            updateAudio(msg.tabId, msg.panning, msg.volume);
+            break;
+        case 'release_tab':
+            releaseTab(msg.tabId);
+            break;
+    }
+});
+
+async function captureTab(tabId, streamId, panning, volume) {
+    // If the service worker restarted and lost its state but this document kept
+    // running, the audio graph already exists — just update the values.
+    if (tabAudio[tabId]) {
+        updateAudio(tabId, panning, volume);
+        return;
+    }
+
+    // getUserMedia with chromeMediaSource:'tab' consumes the one-time streamId
+    // obtained via chrome.tabCapture.getMediaStreamId() in the service worker.
+    // Chrome mutes the tab's own audio output while this stream is active.
+    const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+            mandatory: {
+                chromeMediaSource: 'tab',
+                chromeMediaSourceId: streamId
+            }
+        },
+        video: false
+    });
+
+    const context = new AudioContext();
+    const source = context.createMediaStreamSource(stream);
+    const gainNode = context.createGain();
+    // getUserMedia tab capture returns a stereo stream. StereoPannerNode's
+    // stereo-in algorithm shifts the stereo field rather than panning, which
+    // for correlated content (L≈R) reads as volume change instead of position.
+    // Forcing the gain node to mono triggers the spec's speaker downmix
+    // (0.5·L + 0.5·R) so the panner always receives a true mono signal.
+    gainNode.channelCount = 1;
+    gainNode.channelCountMode = 'explicit';
+    gainNode.gain.setValueAtTime(volume, context.currentTime);
+    const panNode = context.createStereoPanner();
+    panNode.pan.setValueAtTime(panning, context.currentTime);
+    source.connect(gainNode).connect(panNode).connect(context.destination);
+
+    tabAudio[tabId] = { context, source, gainNode, panNode };
+}
+
+function updateAudio(tabId, panning, volume) {
+    const audio = tabAudio[tabId];
+    if (!audio) return;
+    audio.panNode.pan.setValueAtTime(panning, audio.context.currentTime);
+    audio.gainNode.gain.setValueAtTime(volume, audio.context.currentTime);
+}
+
+function releaseTab(tabId) {
+    const audio = tabAudio[tabId];
+    if (!audio) return;
+    audio.source.disconnect();
+    audio.context.close();
+    delete tabAudio[tabId];
+}

--- a/popup.html
+++ b/popup.html
@@ -31,7 +31,6 @@
 			<p style="float:left;width:33.3333%;text-align:right;">100%</p>
 		</div>
 		<input type="range" id="TabDJExtensionVolumeInput" min="0" max="1" step="0.1" value="1">
-		<script type="application/javascript" src="browser-polyfill/browser-polyfill.min.js"></script>
 		<script type="application/javascript" src="popup.js"></script>
 	</body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,99 +1,49 @@
-var port = browser.extension.connect({
-	name: 'Tab DJ'
-});
+const port = chrome.runtime.connect({ name: 'Tab DJ' });
 
-function currenttabcallback(callback)
-{
-	chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
-		var currTab = tabs[0];
-		
-		if (currTab) {
-			callback(currTab.id);
-		}
-	});
+function currenttabcallback(callback) {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        const currTab = tabs[0];
+        if (currTab) callback(currTab.id);
+    });
 }
 
-function setvalue()
-{
-	var panvalue = document.getElementById('TabDJExtensionPanInput').value;
-    var gainvalue = document.getElementById('TabDJExtensionVolumeInput').value;
-	
-	currenttabcallback(function(tabid)
-	{
-		var msgdata = {
-			'type': 'set_request',
-			'value': [
-                panvalue,
-                gainvalue
-            ],
-			'tabid': tabid
-		};
-		
-		port.postMessage(msgdata);
-	});
+function setvalue() {
+    const panvalue = document.getElementById('TabDJExtensionPanInput').value;
+    const gainvalue = document.getElementById('TabDJExtensionVolumeInput').value;
+    currenttabcallback((tabid) => {
+        port.postMessage({ type: 'set_request', value: [panvalue, gainvalue], tabid });
+    });
 }
 
-function update()
-{
-	currenttabcallback(function(tabid)
-	{
-		var msgdata = {
-			'type': 'update_request',
-			'value': [
-                0,
-                1
-            ],
-			'tabid': tabid
-		};
-		
-		port.postMessage(msgdata);
-	});
+function update() {
+    currenttabcallback((tabid) => {
+        port.postMessage({ type: 'update_request', value: [0, 1], tabid });
+    });
 }
 
-port.onMessage.addListener(function(msg)
-{
-	currenttabcallback(function(tabid)
-	{
-		console.log(msg);
-		console.log(tabid);
-		
-		if (msg.tabid == tabid)
-		{
-			if (msg.type == "update_response")
-			{
-				var panvalue = msg.value[0];
-                var gainvalue = msg.value[1];
-				document.getElementById('TabDJExtensionPanInput').value = panvalue;
-                document.getElementById('TabDJExtensionVolumeInput').value = gainvalue;
-			}
-		}
-	});
-});
-
-// https://stackoverflow.com/a/25612056
-function localizeHtmlPage()
-{
-    //Localize by replacing __MSG_***__ meta tags
-    var objects = document.getElementsByTagName('html');
-    for (var j = 0; j < objects.length; j++)
-    {
-        var obj = objects[j];
-
-        var valStrH = obj.innerHTML.toString();
-        var valNewH = valStrH.replace(/__MSG_(\w+)__/g, function(match, v1)
-        {
-            return v1 ? browser.i18n.getMessage(v1) : "";
-        });
-
-        if(valNewH != valStrH)
-        {
-            obj.innerHTML = valNewH;
+port.onMessage.addListener((msg) => {
+    currenttabcallback((tabid) => {
+        if (msg.tabid == tabid && msg.type === 'update_response') {
+            document.getElementById('TabDJExtensionPanInput').value = msg.value[0];
+            document.getElementById('TabDJExtensionVolumeInput').value = msg.value[1];
         }
+    });
+});
+
+function localizeHtmlPage() {
+    const objects = document.getElementsByTagName('html');
+    for (let j = 0; j < objects.length; j++) {
+        const obj = objects[j];
+        const valStrH = obj.innerHTML.toString();
+        const valNewH = valStrH.replace(/__MSG_(\w+)__/g, (match, v1) =>
+            v1 ? chrome.i18n.getMessage(v1) : ''
+        );
+        if (valNewH !== valStrH) obj.innerHTML = valNewH;
     }
 }
 
 localizeHtmlPage();
-document.getElementById('TabDJExtensionPanInput').addEventListener("input", setvalue);
-document.getElementById('TabDJExtensionVolumeInput').addEventListener("input", setvalue);
+document.getElementById('TabDJExtensionPanInput').addEventListener('input', setvalue);
+document.getElementById('TabDJExtensionVolumeInput').addEventListener('input', setvalue);
 
 update();


### PR DESCRIPTION
**Manifest** (manifest.json)

- manifest_version 2 → 3
- browser_action → action
- Persistent background page → service_worker
- Added offscreen and storage permissions
- Dropped browser-polyfill from background scripts

**Service worker** (background.js) — rewritten

- Removed all Web Audio API code (not available in workers)
- browser.extension.onConnect → chrome.runtime.onConnect
- tabCapture.capture() → tabCapture.getMediaStreamId(), forwarding the stream ID to a new offscreen document
- Added offscreen-document lifecycle management (create-if-missing, with a race guard)
- Added chrome.storage.session persistence so slider state survives worker restarts
- Fixed dead mst.type typo bug

**Offscreen document** (offscreen.html + offscreen.js) — new

- Hosts the actual AudioContext, gain node, and pan node per tab (the part Chrome won't kill on idle)
- Handles capture_tab / update_audio / release_tab messages from the service worker
- Calls getUserMedia({chromeMediaSource:'tab'}) to consume the stream ID
- Guards against duplicate captures if the service worker restarts mid-session

**Popup** (popup.js + popup.html)

- browser.* → chrome.* throughout
- Removed browser-polyfill <script> tag
- Fixed currenttabcallable typo (was breaking popup load)
- Removed stray debug console.logs

**Bug fix**: L/R balance acting like volume

- Root cause: MV3's getUserMedia tab capture is stereo, but StereoPannerNode only pans correctly on mono input — stereo input shifts the stereo field instead, which reads as volume change for correlated content
- Fix: force the gain node to mono (channelCount = 1, channelCountMode = 'explicit') before the panner, triggering the standard speaker downmix